### PR TITLE
op3: Remove startOffsetMs and fix highspeed recording

### DIFF
--- a/configs/media_profiles.xml
+++ b/configs/media_profiles.xml
@@ -93,7 +93,7 @@
 <MediaSettings>
     <!-- Each camcorder profile defines a set of predefined configuration parameters -->
     <!-- Back Camera -->
-    <CamcorderProfiles cameraId="0" startOffsetMs="300">
+    <CamcorderProfiles cameraId="0">
 
     <EncoderProfile quality="low" fileFormat="3gp" duration="30">
       <Video codec="h264"
@@ -445,47 +445,6 @@
             channels="2" />
     </EncoderProfile>
 
-    <!-- CAMCORDER_QUALITY_HIGH_SPEED_HIGH/720P : 720p@120fps; 27.0 Mbps -->
-    <EncoderProfile quality="highspeedhigh" fileFormat="mp4" duration="30">
-        <Video codec="h264"
-               bitRate="27000000"
-               width="1280"
-               height="720"
-               frameRate="120" />
-        <!-- audio setting is ignored -->
-        <Audio codec="aac"
-               bitRate="96000"
-               sampleRate="48000"
-               channels="2" />
-    </EncoderProfile>
-
-    <EncoderProfile quality="highspeed720p" fileFormat="mp4" duration="30">
-        <Video codec="h264"
-               bitRate="27000000"
-               width="1280"
-               height="720"
-               frameRate="120" />
-        <!-- audio setting is ignored -->
-        <Audio codec="aac"
-               bitRate="96000"
-               sampleRate="48000"
-               channels="2" />
-    </EncoderProfile>
-
-    <!-- CAMCORDER_QUALITY_HIGH_SPEED_HIGH/1080P : 1080p@60fps; 34.0 Mbps -->
-    <EncoderProfile quality="highspeed1080p" fileFormat="mp4" duration="30">
-        <Video codec="h264"
-               bitRate="34000000"
-               width="1920"
-               height="1080"
-               frameRate="60" />
-        <!-- audio setting is ignored -->
-        <Audio codec="aac"
-               bitRate="96000"
-               sampleRate="48000"
-               channels="2" />
-    </EncoderProfile>
-
         <ImageEncoding quality="95" />
         <ImageEncoding quality="80" />
         <ImageEncoding quality="70" />
@@ -493,7 +452,7 @@
 
     </CamcorderProfiles>
     <!-- Front Camera -->
-    <CamcorderProfiles cameraId="1" startOffsetMs="300">
+    <CamcorderProfiles cameraId="1">
 
     <EncoderProfile quality="low" fileFormat="3gp" duration="30">
       <Video codec="h264"


### PR DESCRIPTION
 * Remove startOffsetMs from media_profile to avoid capturing the video
   record tone while recording the video with CamCorder.
 * Remove broken highspeed recording profiles to fix HFR

Change-Id: I15051d7a5120eaa8c7388d2f4fa3784687e36bed