### PR TITLE
op3: Remove duplicated dalvik heap size config

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -24,7 +24,6 @@ debug.sf.hw=1
 debug.sf.latch_unsignaled=1
 debug.egl.hw=1
 debug.gralloc.enable_fb_ubwc=1
-dalvik.vm.heapsize=36m
 dev.pm.dyn_samplingrate=1
 persist.demo.hdmirotationlock=false
 sdm.debug.disable_skip_validate=1


### PR DESCRIPTION
This one is pulled from stock, but we have already defined dalvik vm
related values in device makefile and this one is a no-op.

Remove this line from system.prop as it is depulicated and actually
very strange (only 36m).

Change-Id: Idad18413b288e5e82eb659f2c8e1d4fe59b3c2b9