### PR TITLE
op3: doze: Use OnePlus pickup sensor for pickup detection

### DIFF
--- a/doze/res/xml/doze_settings.xml
+++ b/doze/res/xml/doze_settings.xml
@@ -17,8 +17,8 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory
-        android:key="tilt_sensor"
-        android:title="@string/tilt_sensor_title">
+        android:key="pickup_sensor"
+        android:title="@string/pickup_sensor_title">
 
         <SwitchPreference
             android:key="gesture_pick_up"

--- a/doze/src/org/lineageos/settings/doze/DozeService.java
+++ b/doze/src/org/lineageos/settings/doze/DozeService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 The CyanogenMod Project
- *               2017 The LineageOS Project
+ *               2017-2018 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,13 +30,13 @@ public class DozeService extends Service {
     private static final boolean DEBUG = false;
 
     private ProximitySensor mProximitySensor;
-    private TiltSensor mTiltSensor;
+    private PickupSensor mPickupSensor;
 
     @Override
     public void onCreate() {
         if (DEBUG) Log.d(TAG, "Creating service");
         mProximitySensor = new ProximitySensor(this);
-        mTiltSensor = new TiltSensor(this);
+        mPickupSensor = new PickupSensor(this);
 
         IntentFilter screenStateFilter = new IntentFilter(Intent.ACTION_SCREEN_ON);
         screenStateFilter.addAction(Intent.ACTION_SCREEN_OFF);
@@ -55,7 +55,7 @@ public class DozeService extends Service {
         super.onDestroy();
         this.unregisterReceiver(mScreenStateReceiver);
         mProximitySensor.disable();
-        mTiltSensor.disable();
+        mPickupSensor.disable();
     }
 
     @Override
@@ -66,7 +66,7 @@ public class DozeService extends Service {
     private void onDisplayOn() {
         if (DEBUG) Log.d(TAG, "Display on");
         if (Utils.pickUpEnabled(this)) {
-            mTiltSensor.disable();
+            mPickupSensor.disable();
         }
         if (Utils.handwaveGestureEnabled(this) ||
                 Utils.pocketGestureEnabled(this)) {
@@ -77,7 +77,7 @@ public class DozeService extends Service {
     private void onDisplayOff() {
         if (DEBUG) Log.d(TAG, "Display off");
         if (Utils.pickUpEnabled(this)) {
-            mTiltSensor.enable();
+            mPickupSensor.enable();
         }
         if (Utils.handwaveGestureEnabled(this) ||
                 Utils.pocketGestureEnabled(this)) {

--- a/doze/src/org/lineageos/settings/doze/PickupSensor.java
+++ b/doze/src/org/lineageos/settings/doze/PickupSensor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 The CyanogenMod Project
- *               2017 The LineageOS Project
+ *               2017-2018 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ import android.hardware.SensorManager;
 import android.os.SystemClock;
 import android.util.Log;
 
-public class TiltSensor implements SensorEventListener {
+public class PickupSensor implements SensorEventListener {
 
     private static final boolean DEBUG = false;
-    private static final String TAG = "TiltSensor";
+    private static final String TAG = "PickupSensor";
 
     private static final int BATCH_LATENCY_IN_MS = 100;
     private static final int MIN_PULSE_INTERVAL_MS = 2500;
@@ -39,10 +39,10 @@ public class TiltSensor implements SensorEventListener {
 
     private long mEntryTimestamp;
 
-    public TiltSensor(Context context) {
+    public PickupSensor(Context context) {
         mContext = context;
         mSensorManager = (SensorManager) mContext.getSystemService(Context.SENSOR_SERVICE);
-        mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_TILT_DETECTOR);
+        mSensor = Utils.getSensor(mSensorManager, "com.oneplus.sensor.pickup");
     }
 
     @Override

--- a/doze/src/org/lineageos/settings/doze/Utils.java
+++ b/doze/src/org/lineageos/settings/doze/Utils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 The CyanogenMod Project
- *               2017 The LineageOS Project
+ *               2017-2018 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.lineageos.settings.doze;
 
 import android.content.Context;
 import android.content.Intent;
+import android.hardware.Sensor;
+import android.hardware.SensorManager;
 import android.os.UserHandle;
 import android.support.v7.preference.PreferenceManager;
 import android.provider.Settings;
@@ -91,5 +93,14 @@ public final class Utils {
     protected static boolean sensorsEnabled(Context context) {
         return pickUpEnabled(context) || handwaveGestureEnabled(context)
                 || pocketGestureEnabled(context);
+    }
+
+    protected static Sensor getSensor(SensorManager sm, String type) {
+        for (Sensor sensor : sm.getSensorList(Sensor.TYPE_ALL)) {
+            if (type.equals(sensor.getStringType())) {
+                return sensor;
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
 * Our tilt sensor doesn't work, but OnePlus implemented a virtual
   pickup sensor, make use of it for pickup detection.
 * Thanks to XiNGRZ <chenxingyu92@gmail.com> for pointing out it.

Change-Id: Ic4f09fef01064b3645253feb9e84dee063769d0e