### PR TITLE
op3: Don't build vendor.lineage.livedisplay-V1.0-java

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -316,11 +316,7 @@ PRODUCT_PACKAGES += \
 
 # LiveDisplay native
 PRODUCT_PACKAGES += \
-    vendor.lineage.livedisplay@1.0-service-sdm \
-    vendor.lineage.livedisplay-V1.0-java
-
-PRODUCT_BOOT_JARS += \
-    vendor.lineage.livedisplay-V1.0-java
+    vendor.lineage.livedisplay@1.0-service-sdm
 
 # Media
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
 * The static version is in use now.

Change-Id: I406ef69754561b81e4260e16fb2d534438adf3b9